### PR TITLE
Fix minVersion tags

### DIFF
--- a/src/plugins/scm-branchwp-plugin/releases/2-0-0-rc3.yaml
+++ b/src/plugins/scm-branchwp-plugin/releases/2-0-0-rc3.yaml
@@ -4,4 +4,4 @@ date: '2020-01-29T12:44:52Z'
 url: https://maven.scm-manager.org/nexus/content/repositories/plugin-releases/sonia/scm/plugins/scm-branchwp-plugin/2.0.0-rc3/scm-branchwp-plugin-2.0.0-rc3.smp
 checksum: ae2d787e14226d4b5c0687fe1d08ed5abd243160bc1e0de2e547e57083a04357
 conditions:
-  min-version: 2.0.0-rc2
+  minVersion: 2.0.0-rc2

--- a/src/plugins/scm-cockpit-legacy-plugin/releases/2-0-0-rc1.yaml
+++ b/src/plugins/scm-cockpit-legacy-plugin/releases/2-0-0-rc1.yaml
@@ -8,4 +8,4 @@ dependencies:
 - scm-activity-plugin
 - scm-statistic-plugin
 conditions:
-  min-version: 2.0.0-rc1
+  minVersion: 2.0.0-rc1

--- a/src/plugins/scm-editor-plugin/releases/2-0-0-rc2.yaml
+++ b/src/plugins/scm-editor-plugin/releases/2-0-0-rc2.yaml
@@ -4,4 +4,4 @@ date: '2020-01-29T10:56:02Z'
 url: https://maven.scm-manager.org/nexus/content/repositories/plugin-releases/sonia/scm/plugins/scm-editor-plugin/2.0.0-rc2/scm-editor-plugin-2.0.0-rc2.smp
 checksum: c2745a7005519acdde7f7be9f3fbdaa1fd5413c15c9b8aeebdd3f01e007e048b
 conditions:
-  min-version: 2.0.0-rc2
+  minVersion: 2.0.0-rc2

--- a/src/plugins/scm-jenkins-plugin/releases/2-0-0-rc1.yaml
+++ b/src/plugins/scm-jenkins-plugin/releases/2-0-0-rc1.yaml
@@ -4,4 +4,4 @@ date: '2019-12-03T10:15:26Z'
 url: https://maven.scm-manager.org/nexus/content/repositories/plugin-releases/sonia/scm/plugins/scm-jenkins-plugin/2.0.0-rc1/scm-jenkins-plugin-2.0.0-rc1.smp
 checksum: 891609773368c64515299d6800eaa3f6e958db1ee6549d6165a00859e0ec7a33
 conditions:
-  min-version: 2.0.0-rc1
+  minVersion: 2.0.0-rc1

--- a/src/plugins/scm-jira-plugin/releases/2-0-0-rc1.yaml
+++ b/src/plugins/scm-jira-plugin/releases/2-0-0-rc1.yaml
@@ -7,4 +7,4 @@ dependencies:
 - scm-mail-plugin
 - scm-issuetracker-plugin
 conditions:
-  min-version: 2.0.0-rc1
+  minVersion: 2.0.0-rc1

--- a/src/plugins/scm-pathwp-plugin/releases/2-0-0-rc2.yaml
+++ b/src/plugins/scm-pathwp-plugin/releases/2-0-0-rc2.yaml
@@ -4,4 +4,4 @@ date: '2020-01-29T12:26:06Z'
 url: https://maven.scm-manager.org/nexus/content/repositories/plugin-releases/sonia/scm/plugins/scm-pathwp-plugin/2.0.0-rc2/scm-pathwp-plugin-2.0.0-rc2.smp
 checksum: b4f0a8a8262d30d2765aea07a197980b3b16fff82e1200c02178825d3cbf8351
 conditions:
-  min-version: 2.0.0-rc2
+  minVersion: 2.0.0-rc2

--- a/src/plugins/scm-readme-plugin/releases/2-0-0-rc2.yaml
+++ b/src/plugins/scm-readme-plugin/releases/2-0-0-rc2.yaml
@@ -4,4 +4,4 @@ date: '2020-01-29T12:32:21Z'
 url: https://maven.scm-manager.org/nexus/content/repositories/plugin-releases/sonia/scm/plugins/scm-readme-plugin/2.0.0-rc2/scm-readme-plugin-2.0.0-rc2.smp
 checksum: 2750bbfcea67d7adf9a75f67fb934fb858a6cb5623b4f6a282c30103cefe127d
 conditions:
-  min-version: 2.0.0-rc2
+  minVersion: 2.0.0-rc2

--- a/src/plugins/scm-redmine-plugin/releases/2-0-0-rc1.yaml
+++ b/src/plugins/scm-redmine-plugin/releases/2-0-0-rc1.yaml
@@ -6,4 +6,4 @@ checksum: 834285e06b2ca45896a5b1cbb531bc262a78eb177117d3a8ce6f8b45f3ed33be
 dependencies:
 - scm-issuetracker-plugin
 conditions:
-  min-version: 2.0.0-rc1
+  minVersion: 2.0.0-rc1

--- a/src/plugins/scm-review-plugin/releases/2-0-0-rc1.yaml
+++ b/src/plugins/scm-review-plugin/releases/2-0-0-rc1.yaml
@@ -6,4 +6,4 @@ checksum: fa8ab7513e01cc0865f6fd1779df908da778907d1cd444eff604659b737e5e3e
 dependencies:
 - scm-mail-plugin
 conditions:
-  min-version: 2.0.0-rc1
+  minVersion: 2.0.0-rc1

--- a/src/plugins/scm-review-plugin/releases/2-0-0-rc2.yaml
+++ b/src/plugins/scm-review-plugin/releases/2-0-0-rc2.yaml
@@ -6,4 +6,4 @@ checksum: 0c1c5fbdcb65e8ffe7ae896bdff9491522662fab08404afb8f6c7e706ddb9f73
 dependencies:
 - scm-mail-plugin
 conditions:
-  min-version: 2.0.0-rc2
+  minVersion: 2.0.0-rc2

--- a/src/plugins/scm-review-plugin/releases/2-0-0-rc3.yaml
+++ b/src/plugins/scm-review-plugin/releases/2-0-0-rc3.yaml
@@ -6,4 +6,4 @@ checksum: 331a394d4977cb208207e1ebc38397aa685b66f2c91babcbb04e894777b1c1ac
 dependencies:
 - scm-mail-plugin
 conditions:
-  min-version: 2.0.0-rc4
+  minVersion: 2.0.0-rc4

--- a/src/plugins/scm-ssh-plugin/releases/2-0-0-rc2.yaml
+++ b/src/plugins/scm-ssh-plugin/releases/2-0-0-rc2.yaml
@@ -4,4 +4,4 @@ date: '2020-01-29T10:50:35Z'
 url: https://maven.scm-manager.org/nexus/content/repositories/plugin-releases/sonia/scm/plugins/scm-ssh-plugin/2.0.0-rc2/scm-ssh-plugin-2.0.0-rc2.smp
 checksum: a7ef11bdfcad0cc4a01fed090458deef647dccfb3187be7324e6b6d40ccc2c29
 conditions:
-  min-version: 2.0.0-rc2
+  minVersion: 2.0.0-rc2


### PR DESCRIPTION
The tag 'min-version' is wrong and has to be replaced with 'minVersion'. Otherwise this is not checked by the plugin center api.